### PR TITLE
ldaptemplates - add brackets to filter

### DIFF
--- a/src/containers/LdapConfig.js
+++ b/src/containers/LdapConfig.js
@@ -309,12 +309,12 @@ const LdapConfig = props => {
         username: 'mail',
         displayName: 'displayName',
         searchAttributes: ["mail", "givenName", "cn", "sn", "name", "displayName"],
-        filter: "objectClass=user",
-        contactFilter: "objectclass=contact",
+        filter: '(objectClass=user)',
+        contactFilter: '(objectclass=contact)',
         aliases: 'proxyAddresses',
         groupMemberAttr: "memberOf",
         groupaddr: "mail",
-        groupfilter: "(objectclass=group)",
+        groupfilter: '(objectclass=group)',
         groupname: "cn",
       });
     } else if(templates === 'OpenLDAP') {
@@ -325,12 +325,12 @@ const LdapConfig = props => {
         username: 'mail',
         displayName: 'displayName',
         searchAttributes: ["mail", "givenName", "cn", "sn", "displayName", "gecos"],
-        filter: "objectClass=posixAccount",
+        filter: '(objectClass=posixAccount)',
         contactFilter: '(&(|(objectclass=person)(objectclass=inetOrgPerson))(!(objectclass=posixAccount))(!(objectclass=shadowAccount)))',
         aliases: 'mailAlternativeAddress',
         groupMemberAttr: "memberOf",
         groupaddr: "mailPrimaryAddress",
-        groupfilter: "(objectclass=posixgroup)",
+        groupfilter: '(objectclass=posixgroup)',
         groupname: "cn",
       });
     } else if(templates === 'Univention') {
@@ -341,12 +341,12 @@ const LdapConfig = props => {
         username: 'mailPrimaryAddress',
         displayName: 'displayName',
         searchAttributes: ["mail", "givenName", "cn", "sn", "displayName", "gecos"],
-        filter: "objectClass=posixAccount",
+        filter: '(objectClass=posixAccount)',
         contactFilter: '(&(|(objectclass=person)(objectclass=inetOrgPerson))(!(objectclass=posixAccount))(!(objectclass=shadowAccount)))',
         aliases: 'mailAlternativeAddress',
         groupMemberAttr: "memberOf",
         groupaddr: "mailPrimaryAddress",
-        groupfilter: "(objectclass=posixgroup)",
+        groupfilter: '(objectclass=posixgroup)'
         groupname: "cn",
       });
     } else if(templates === '389ds') {
@@ -357,12 +357,12 @@ const LdapConfig = props => {
         username: 'mail',
         displayName: 'displayName',
         searchAttributes: ["mail", "givenName", "cn", "sn", "displayName"],
-        filter: "objectClass=posixAccount",
+        filter: '(objectClass=posixAccount)',
         contactFilter: '(&(|(objectclass=person)(objectclass=inetOrgPerson))(!(objectclass=posixAccount)))',
         aliases: 'mailAlternateAddress',
         groupMemberAttr: "memberOf",
         groupaddr: "mail",
-        groupfilter: "(objectclass=posixGroup)",
+        groupfilter: '(objectclass=posixGroup)',
         groupname: "cn",
       });
     } else {


### PR DESCRIPTION
avoid `An error occurred: LDAPInvalidFilterError('malformed filter').` when using a directory template.