### PR TITLE
Fix minor glitches in developer mode on ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PACKAGE_NAME = grommunio-admin-web
 
 # Tools
 
-YARN ?= yarn
+YARN ?= $(shell command -v yarn >/dev/null 2>&1 && echo yarn || echo yarnpkg)
 
 # Variables
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ yarn start
 ## caddy
 
 ### Installation
-According to https://caddyserver.com/docs/install
+According to https://caddyserver.com/docs/install#debian-ubuntu-raspbian
 ```
-sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo apt-key add -
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/setup/config.deb.txt?distro=debian&version=any-version' | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update
 sudo apt install caddy
@@ -142,7 +142,7 @@ Each hostname is the key of an object, which has following keys:
       "logo": "anotherUrl.to/logo.png",
       "logoLight": "anotherUrl.to/light/logo.png",
       "icon": "anotherUrl.to/light/icon.svg"
-    },
+    }
   }
   ```
 As you can see, it is not necessary to overwrite every image, but the hostnames need to be accurate.


### PR DESCRIPTION
- Ubuntu uses the binary `yarnpkg` for Yarn. The makefile should use that name as a fallback if `yarn` is not found
- Update install instructions for Caddy.
- Fix json syntax in example